### PR TITLE
remove BERTopic import in inference script

### DIFF
--- a/src/inference/main.py
+++ b/src/inference/main.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List
 
-from bertopic import BERTopic
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -39,7 +38,7 @@ def get_or_create_db_topic(
 
 def retrain(
         session: Session,
-        model: BERTopic,
+        model,
 ):
     titles = session.execute(
         select(StoryModel.title)
@@ -49,7 +48,7 @@ def retrain(
 
 
 def run_inference(
-        model: BERTopic,
+        model,
         session: Session,
 ):
     db_stories = session.query(StoryModel).all()
@@ -65,7 +64,7 @@ def run_inference(
 
 def run_clustering(
         session: Session,
-        model: BERTopic
+        model,
 ):
     """
     trains a new version of the model on the entire ingested story titles and runs inference on each of them


### PR DESCRIPTION
importing BERTopic slowed unit testing immensely. it was only used as a typehint. will explore other alternatives later